### PR TITLE
News: NickServ RESETPASS self-service password recovery

### DIFF
--- a/content/news/nickserv-resetpass.md
+++ b/content/news/nickserv-resetpass.md
@@ -1,0 +1,42 @@
+---
+title: "NickServ: nuovo comando RESETPASS per recuperare la password"
+date: 2026-04-20
+author: "Staff Azzurra"
+tags: ["annuncio", "services", "nickserv"]
+summary: "Chi ha dimenticato la password del nick e ha un'e-mail registrata valida può ora resettarla in autonomia tramite un codice di autorizzazione inviato via e-mail."
+---
+
+Siamo lieti di annunciare una **nuova funzionalità dei servizi**: il comando **RESETPASS** di NickServ, che permette di reimpostare la password del proprio nick quando la si è dimenticata — a patto di avere un'**e-mail registrata valida**.
+
+Fino ad oggi l'unico modo per recuperare un nick con password persa era passare dallo staff. Da adesso la procedura è completamente **self-service** e basata sull'e-mail già associata al nick.
+
+## Come funziona
+
+Il flusso è in **due passaggi** e richiede che un services operator esegua per te il primo passo (per evitare abusi automatizzati):
+
+1. Uno services operator esegue `/ns SENDPASS <nick>` — i servizi inviano all'e-mail registrata un **codice di autorizzazione** monouso.
+2. Tu, controllata la casella, esegui:
+
+   ```
+   /ns RESETPASS <nick> <codice> <nuova-password>
+   ```
+
+   Se il codice è corretto, la password viene sostituita immediatamente e puoi fare `/ns identify` con la nuova.
+
+## Requisiti
+
+- Il nick deve avere un'**e-mail registrata** e ancora valida.
+- La password precedente **non è necessaria** — lo scopo del comando è proprio recuperare l'accesso senza conoscerla.
+- Il codice è monouso e ha una scadenza; se scade, basta richiedere un nuovo SENDPASS.
+
+## Come si chiede un reset
+
+Se hai perso la password e hai ancora accesso all'e-mail registrata, scrivi in `#IRCHelp` chiedendo a uno staffer di eseguire lo `SENDPASS` per il tuo nick. Ricevuto il codice via e-mail, procedi autonomamente con `RESETPASS`.
+
+Se invece **non hai più accesso** all'e-mail registrata, il reset self-service non è possibile: in quel caso resta valida la procedura manuale tramite staff.
+
+---
+
+Come sempre, continuiamo a lavorare per rendere i servizi più accessibili e la vita degli utenti più semplice.
+
+Ci vediamo in chat 👋


### PR DESCRIPTION
Annuncia la nuova funzionalità **RESETPASS** di NickServ shippata in [services#5](https://github.com/azzurra/services/pull/5).

## Cosa copre la news

- Flusso self-service in due passaggi: oper esegue `/ns SENDPASS <nick>`, l'utente riceve un codice via e-mail, poi `/ns RESETPASS <nick> <codice> <nuova-password>`.
- Requisito: e-mail registrata valida.
- Fallback manuale via staff se la mail non è più accessibile.

## Note

Questa PR sostituisce la #7 (chiusa): la history del branch precedente conteneva un riferimento al comando oper-only `AUTHRESET RESETPASS`. Questo branch nasce pulito da `master` e non ha mai contenuto quel riferimento.

File: `content/news/nickserv-resetpass.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)