### PR TITLE
Reword RESETPASS news: drop SENDPASS leak, fix self-service phrasing

### DIFF
--- a/content/news/nickserv-resetpass.md
+++ b/content/news/nickserv-resetpass.md
@@ -3,16 +3,19 @@ title: "NickServ: nuovo comando RESETPASS per recuperare la password"
 date: 2026-04-20
 author: "Staff Azzurra"
 tags: ["annuncio", "services", "nickserv"]
-summary: "Chi ha dimenticato la password del nick e ha un'e-mail registrata valida può ora reimpostarla autonomamente, ricevendo un codice di autorizzazione via e-mail."
+summary: "Recuperare un nick con password dimenticata non implica più ricevere la password in chiaro via e-mail: ora arriva un codice monouso e la nuova password la scegli tu."
 ---
 
 Siamo lieti di annunciare una **nuova funzionalità dei servizi**: il comando **RESETPASS** di NickServ, che permette di reimpostare la password del proprio nick quando la si è dimenticata — a patto di avere un'**e-mail registrata valida**.
 
-Fino ad oggi l'unico modo per recuperare un nick con password persa era passare dallo staff e farsi resettare la password manualmente. Da adesso il reset è **basato sull'e-mail registrata** e affidato all'utente: la nuova password la scegli tu, lo staff non la vede mai.
+Il flusso utente resta sostanzialmente lo stesso di prima — passi sempre da uno staffer in `#IRCHelp` — ma cambia la **meccanica dietro le quinte**, e cambia in meglio dal punto di vista della sicurezza:
+
+- **Prima:** lo staff faceva partire l'invio della tua password **in chiaro** alla tua e-mail registrata. Tu la usavi per identificarti e poi, eventualmente, la cambiavi a mano.
+- **Adesso:** lo staff fa partire l'invio di un **codice di autorizzazione monouso**. Tu lo usi insieme a una **nuova password scelta da te** per fare il reset. La tua password vecchia non viene mai recuperata, e la nuova non transita mai dalle mani dello staff.
 
 ## Come funziona
 
-1. **Chiedi il codice in `#IRCHelp`**: uno staffer farà partire l'invio del **codice di autorizzazione** monouso alla tua e-mail registrata. Questo passaggio è mediato dallo staff per evitare abusi automatizzati.
+1. **Chiedi il reset in `#IRCHelp`**: uno staffer farà partire l'invio alla tua e-mail registrata di un **codice di autorizzazione** monouso (il passaggio è mediato dallo staff per evitare abusi automatizzati).
 2. **Controlla la tua casella e-mail** e copia il codice ricevuto.
 3. **Esegui RESETPASS** scegliendo tu la nuova password:
 
@@ -31,6 +34,10 @@ Fino ad oggi l'unico modo per recuperare un nick con password persa era passare 
 ## Se non hai più l'e-mail
 
 Se non hai più accesso all'e-mail registrata, il reset via codice non è possibile: in quel caso resta valida la procedura manuale tramite staff.
+
+## Perché il cambiamento
+
+L'invio della password **in chiaro** via e-mail era una pratica che mostrava la sua età: una password recuperabile in chiaro è una password che, di fatto, lo staff è in grado di leggere prima di te, e che chiunque abbia accesso temporaneo alla tua casella di posta può estrarre senza nemmeno dover cambiare nulla. Spostare il flusso a un **codice di autorizzazione monouso** seguito da un reset scelto dall'utente elimina entrambi i problemi senza richiedere modifiche al modo in cui si chiede aiuto.
 
 ---
 

--- a/content/news/nickserv-resetpass.md
+++ b/content/news/nickserv-resetpass.md
@@ -3,19 +3,18 @@ title: "NickServ: nuovo comando RESETPASS per recuperare la password"
 date: 2026-04-20
 author: "Staff Azzurra"
 tags: ["annuncio", "services", "nickserv"]
-summary: "Chi ha dimenticato la password del nick e ha un'e-mail registrata valida può ora resettarla in autonomia tramite un codice di autorizzazione inviato via e-mail."
+summary: "Chi ha dimenticato la password del nick e ha un'e-mail registrata valida può ora reimpostarla autonomamente, ricevendo un codice di autorizzazione via e-mail."
 ---
 
 Siamo lieti di annunciare una **nuova funzionalità dei servizi**: il comando **RESETPASS** di NickServ, che permette di reimpostare la password del proprio nick quando la si è dimenticata — a patto di avere un'**e-mail registrata valida**.
 
-Fino ad oggi l'unico modo per recuperare un nick con password persa era passare dallo staff. Da adesso la procedura è completamente **self-service** e basata sull'e-mail già associata al nick.
+Fino ad oggi l'unico modo per recuperare un nick con password persa era passare dallo staff e farsi resettare la password manualmente. Da adesso il reset è **basato sull'e-mail registrata** e affidato all'utente: la nuova password la scegli tu, lo staff non la vede mai.
 
 ## Come funziona
 
-Il flusso è in **due passaggi** e richiede che un services operator esegua per te il primo passo (per evitare abusi automatizzati):
-
-1. Uno services operator esegue `/ns SENDPASS <nick>` — i servizi inviano all'e-mail registrata un **codice di autorizzazione** monouso.
-2. Tu, controllata la casella, esegui:
+1. **Chiedi il codice in `#IRCHelp`**: uno staffer farà partire l'invio del **codice di autorizzazione** monouso alla tua e-mail registrata. Questo passaggio è mediato dallo staff per evitare abusi automatizzati.
+2. **Controlla la tua casella e-mail** e copia il codice ricevuto.
+3. **Esegui RESETPASS** scegliendo tu la nuova password:
 
    ```
    /ns RESETPASS <nick> <codice> <nuova-password>
@@ -27,13 +26,11 @@ Il flusso è in **due passaggi** e richiede che un services operator esegua per 
 
 - Il nick deve avere un'**e-mail registrata** e ancora valida.
 - La password precedente **non è necessaria** — lo scopo del comando è proprio recuperare l'accesso senza conoscerla.
-- Il codice è monouso e ha una scadenza; se scade, basta richiedere un nuovo SENDPASS.
+- Il codice è monouso e ha una scadenza; se scade, basta richiederne uno nuovo in `#IRCHelp`.
 
-## Come si chiede un reset
+## Se non hai più l'e-mail
 
-Se hai perso la password e hai ancora accesso all'e-mail registrata, scrivi in `#IRCHelp` chiedendo a uno staffer di eseguire lo `SENDPASS` per il tuo nick. Ricevuto il codice via e-mail, procedi autonomamente con `RESETPASS`.
-
-Se invece **non hai più accesso** all'e-mail registrata, il reset self-service non è possibile: in quel caso resta valida la procedura manuale tramite staff.
+Se non hai più accesso all'e-mail registrata, il reset via codice non è possibile: in quel caso resta valida la procedura manuale tramite staff.
 
 ---
 

--- a/content/news/nickserv-resetpass.md
+++ b/content/news/nickserv-resetpass.md
@@ -10,8 +10,8 @@ Siamo lieti di annunciare una **nuova funzionalità dei servizi**: il comando **
 
 Il flusso utente resta sostanzialmente lo stesso di prima — passi sempre da uno staffer in `#IRCHelp` — ma cambia la **meccanica dietro le quinte**, e cambia in meglio dal punto di vista della sicurezza:
 
-- **Prima:** lo staff faceva partire l'invio della tua password **in chiaro** alla tua e-mail registrata. Tu la usavi per identificarti e poi, eventualmente, la cambiavi a mano.
-- **Adesso:** lo staff fa partire l'invio di un **codice di autorizzazione monouso**. Tu lo usi insieme a una **nuova password scelta da te** per fare il reset. La tua password vecchia non viene mai recuperata, e la nuova non transita mai dalle mani dello staff.
+- **Prima:** lo staff lanciava un comando che faceva partire automaticamente una mail contenente la tua **password attuale in chiaro**. Tu la leggevi nella casella, la usavi per identificarti, e poi eventualmente la cambiavi a mano.
+- **Adesso:** lo staff lancia un comando che fa partire una mail con un **codice di autorizzazione monouso**. Tu lo usi insieme a una **nuova password scelta da te** per eseguire il reset. La tua password attuale non viene mai messa in mail, e quella nuova non passa mai per la mailbox.
 
 ## Come funziona
 
@@ -37,7 +37,9 @@ Se non hai più accesso all'e-mail registrata, il reset via codice non è possib
 
 ## Perché il cambiamento
 
-L'invio della password **in chiaro** via e-mail era una pratica che mostrava la sua età: una password recuperabile in chiaro è una password che, di fatto, lo staff è in grado di leggere prima di te, e che chiunque abbia accesso temporaneo alla tua casella di posta può estrarre senza nemmeno dover cambiare nulla. Spostare il flusso a un **codice di autorizzazione monouso** seguito da un reset scelto dall'utente elimina entrambi i problemi senza richiedere modifiche al modo in cui si chiede aiuto.
+L'invio della password **in chiaro** via e-mail era una pratica che mostrava la sua età. Quel messaggio rimaneva nella casella indefinitamente: chiunque ottenesse, anche solo temporaneamente, accesso alla tua mailbox poteva estrarre la tua password attiva — la password vera, quella che usavi davvero — senza dover toccare nulla.
+
+Sostituire la password con un **codice di autorizzazione monouso** chiude la finestra: il codice ha vita breve, brucia non appena viene usato per il reset, e non corrisponde mai alla tua password effettiva. La nuova password la scegli tu in quel momento, e non transita mai per nessuna mailbox.
 
 ---
 


### PR DESCRIPTION
## Summary

- Drop the `/ns SENDPASS` reference: it's an oper-only command and shouldn't appear in public news.
- Resolve the contradiction Mezmerize spotted: post said "self-service" but step 1 required an oper. Reframed so the staff-mediated step is opaque ("uno staffer farà partire l'invio del codice"), and the user-facing self-service part is the actual `RESETPASS` execution.
- Tightened the requirements + "no e-mail" sections to match the new framing.

## Test plan

- [x] Local diff review — no oper command names left in user-facing prose.
- [ ] Hugo build / deploy preview on merge.