### PR TITLE
Add GameBot announcement news post

### DIFF
--- a/content/news/gamebot.md
+++ b/content/news/gamebot.md
@@ -1,0 +1,38 @@
+---
+title: "GameBot è arrivato su Azzurra!"
+date: 2026-05-10
+author: "Staff Azzurra"
+tags: ["annuncio", "bot", "giochi"]
+summary: "Sfide di carte, poker, quiz e UNO direttamente in canale: GameBot porta i giochi da tavolo su Azzurra."
+---
+
+## Una nuova compagnia in chat 🎲
+Siamo felici di presentare **GameBot**, il nuovo bot ufficiale di Azzurra dedicato ai giochi in canale. Pensato per ravvivare le serate e per ritrovare quell'atmosfera da tavolo virtuale che da sempre accompagna le community IRC, GameBot porta nelle nostre stanze quattro classici intramontabili.
+
+## I giochi disponibili
+- 🃏 **Sette e Mezzo**: il classico gioco di carte italiano, dove fortuna e nervi saldi fanno la differenza. Avvicinati al sette e mezzo senza sballare.
+- ♠️ **Texas Hold'em**: il poker più diffuso al mondo, in versione canale. Bluff, raise e all-in tra amici, senza puntate reali ma con tutto l'ego in palio.
+- 🧠 **Trivia**: domande a raffica su cultura generale, cinema, musica, sport e tanto altro. Il più rapido vince.
+- 🎴 **UNO**: il gioco di carte che non ha bisogno di presentazioni. Pesca due, salta turno, cambia colore — e non dimenticarti mai di dichiarare "UNO!".
+
+## Come iniziare a giocare
+Per avere GameBot nel proprio canale basta invitarlo:
+
+```
+/invite GameBot #ilmiocanale
+```
+
+Una volta entrato, l'elenco completo dei giochi disponibili si ottiene con:
+
+```
+!listgames
+```
+
+Da lì in poi, ogni partita si avvia con i comandi dedicati che GameBot illustra al volo.
+
+## Perché GameBot
+Crediamo che IRC sia molto più di una chat: è un luogo di socialità. GameBot nasce per offrire un motivo in più per restare connessi, sfidarsi tra amici e fare nuove conoscenze attorno a un tavolo virtuale. Niente app da installare, niente account aggiuntivi: bastano i comandi che già conosci.
+
+Buon divertimento, e che vinca il migliore!
+
+Ci vediamo in chat 👋

--- a/content/news/gamebot.md
+++ b/content/news/gamebot.md
@@ -12,7 +12,7 @@ Siamo felici di presentare **GameBot**, il nuovo bot ufficiale di Azzurra dedica
 ## I giochi disponibili
 - 🃏 **Sette e Mezzo**: il classico gioco di carte italiano, dove fortuna e nervi saldi fanno la differenza. Avvicinati al sette e mezzo senza sballare.
 - ♠️ **Texas Hold'em**: il poker più diffuso al mondo, in versione canale. Bluff, raise e all-in tra amici, senza puntate reali ma con tutto l'ego in palio.
-- 🧠 **Trivia**: domande a raffica su cultura generale, cinema, musica, sport e tanto altro. Il più rapido vince.
+- 🧠 **Trivia**: domande a raffica su cultura generale, cinema, musica, sport e tanto altro.
 - 🎴 **UNO**: il gioco di carte che non ha bisogno di presentazioni. Pesca due, salta turno, cambia colore — e non dimenticarti mai di dichiarare "UNO!".
 
 ## Come iniziare a giocare


### PR DESCRIPTION
## Summary
- Annuncio GameBot per content/news (sette-e-mezzo, holdem, trivia, uno).
- Comandi utente inclusi: `/invite GameBot #chan` + `!listgames`.
- Tono e struttura allineati a `nuovi-server-2026.md` e altri post recenti.

Richiesto da Hypnotize su #it-opers; bozza precedente sul gist, qui senza la riga sulle penalità del Trivia su sua indicazione.

## Test plan
- [ ] Verificare anteprima Hugo (slug, data, summary in feed).
- [ ] Eventuale screenshot del bot in azione, se serve.