### PR TITLE
footer: add morph to the staff line

### DIFF
--- a/themes/azzurra/layouts/_default/baseof.html
+++ b/themes/azzurra/layouts/_default/baseof.html
@@ -82,7 +82,7 @@
     </div>
     <div class="footer-bottom">
       <span>{{ i18n "footerCopyright" (dict "Year" now.Year) }}</span>
-      <span>{{ i18n "footerStaffPrefix" }} <a href="mailto:hypnotize@azzurra.chat">Hypnotize</a> · <a href="mailto:sonic@azzurra.chat">Sonic</a> · <a href="mailto:joep@azzurra.chat">joep</a> · <a href="mailto:mezmerize@azzurra.chat">Mezmerize</a> · <a href="mailto:scorpion@azzurra.chat">Scorpion</a> · <a href="mailto:vjt@azzurra.chat">vjt</a></span>
+      <span>{{ i18n "footerStaffPrefix" }} <a href="mailto:hypnotize@azzurra.chat">Hypnotize</a> · <a href="mailto:sonic@azzurra.chat">Sonic</a> · <a href="mailto:joep@azzurra.chat">joep</a> · <a href="mailto:mezmerize@azzurra.chat">Mezmerize</a> · <a href="mailto:scorpion@azzurra.chat">Scorpion</a> · <a href="mailto:vjt@azzurra.chat">vjt</a> · <a href="mailto:morpheus@azzurra.chat">morph</a></span>
     </div>
   </footer>
 


### PR DESCRIPTION
Adds `morph` to the staff row in the site footer, with `morpheus@azzurra.chat` as the contact address.

Requested on #it-opers. Single-line change in `themes/azzurra/layouts/_default/baseof.html`; appended at the end of the existing list, same `mailto:` markup as the other entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)