### PR TITLE
theme: fix double-escaped entities in news summaries

### DIFF
--- a/themes/azzurra/layouts/_default/list.html
+++ b/themes/azzurra/layouts/_default/list.html
@@ -23,7 +23,7 @@
       {{ end }}{{ end }}
     </div>
     <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
-    <p>{{ .Summary | plainify | truncate 220 }}</p>
+    <p>{{ .Summary | plainify | htmlUnescape | truncate 220 }}</p>
     <a class="read-more" href="{{ .Permalink }}">{{ i18n "readMore" }}</a>
   </article>
   {{ end }}

--- a/themes/azzurra/layouts/index.html
+++ b/themes/azzurra/layouts/index.html
@@ -41,7 +41,7 @@
         {{ end }}{{ end }}
       </div>
       <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
-      <p>{{ .Summary | plainify | truncate 200 }}</p>
+      <p>{{ .Summary | plainify | htmlUnescape | truncate 200 }}</p>
       <a class="read-more" href="{{ .Permalink }}">{{ i18n "readMore" }}</a>
     </article>
     {{ else }}


### PR DESCRIPTION
## Symptom

On <https://www.azzurra.chat/> the news summary reads `ha un&rsquo;e-mail registrata` — the entity is printed verbatim instead of the apostrophe. The single article page `/it/news/nickserv-resetpass/` renders correctly.

The Markdown source (`content/it/news/nickserv-resetpass.md`) uses a plain ASCII apostrophe, so this is not a content problem.

## Cause

Goldmark's typographer rewrites `'` as the `&rsquo;` HTML entity. In the two list templates the summary goes through:

```
{{ .Summary | plainify | truncate N }}
```

`plainify` strips tags but leaves entities intact, and on Hugo 0.128.0 — the version pinned in `.github/workflows/hugo.yml` — the `&` is escaped again on output, producing `&amp;rsquo;`. Article pages are unaffected because they render `.Content`, which is already `template.HTML`.

## Fix

Add `htmlUnescape` after `plainify` in the two affected templates (`themes/azzurra/layouts/index.html`, `themes/azzurra/layouts/_default/list.html`). The order matters: tags are stripped first, entities decoded afterwards.

## Verification

Site built locally with both the pinned 0.128.0 and a newer 0.145.0:

| build | `&amp;rsquo;` on home | site-wide occurrences |
|---|---|---|
| 0.128.0, before | present | 1 |
| 0.128.0, after | gone | 0 |
| 0.145.0, after | gone | 0 |

After the fix the home page renders `ha un’e-mail registrata` on both versions. Note that 0.145.0 does not exhibit the bug even without the patch, so a Hugo bump would also mask it — the `htmlUnescape` is the version-independent fix.

Reported by Hypnotize and Sonic on #it-opers.