### PR TITLE
ci: bump Hugo to 0.164.0 and migrate deprecated language keys

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.128.0
+      HUGO_VERSION: 0.164.0
     steps:
       - name: Install Hugo CLI
         run: |

--- a/hugo.toml
+++ b/hugo.toml
@@ -19,8 +19,8 @@ defaultContentLanguageInSubdir = false
 # Italian (default — served at /)
 # ─────────────────────────────────────────────────────────────────────
 [languages.it]
-  languageName = "Italiano"
-  languageCode = "it-IT"
+  label        = "Italiano"
+  locale       = "it-IT"
   contentDir   = "content/it"
   weight       = 1
 
@@ -112,8 +112,8 @@ defaultContentLanguageInSubdir = false
 # English (served at /en/)
 # ─────────────────────────────────────────────────────────────────────
 [languages.en]
-  languageName = "English"
-  languageCode = "en-US"
+  label        = "English"
+  locale       = "en-US"
   contentDir   = "content/en"
   weight       = 2
 


### PR DESCRIPTION
Requested by Hypnotize on #it-opers, following #16.

## Why the pin was where it was

`HUGO_VERSION: 0.128.0` is not a deliberate choice — it is the default carried by GitHub's *"Sample workflow for building and deploying a Hugo site to GitHub Pages"* template, whose header is still at the top of the file.

From the history, all on 2026-03-29:

| commit | what happened |
|---|---|
| `3ec3a17` | workflow added with `HUGO_VERSION: 0.158.0` |
| `3db55d0` | workflow deleted |
| `56c11a4` | workflow recreated from the GitHub sample, bringing `0.128.0` back |

So the pin regressed by 30 releases in a copy-paste, and 0.128.0 happens to be a version where `plainify` leaves the news summary open to the double escaping fixed in #16.

## What this changes

- `HUGO_VERSION` 0.128.0 → 0.164.0 (latest release, 2026-07-06).
- Two config keys renamed in 0.158.0, migrated so the build stays warning-free:
  - `languages.<lang>.languageName` → `label`
  - `languages.<lang>.languageCode` → `locale`

No template reads either key — the language switcher in `baseof.html` goes through `.Lang` only — so the rename is config-only.

## Verification

Site built with hugo 0.164.0 extended:

- 42 IT pages + 41 EN pages, 90 HTML files — same as before the bump.
- No deprecation warnings left for the language keys.
- Zero `&amp;rsquo;` occurrences site-wide.

## Not in this PR

One unrelated deprecation remains and is left for a follow-up: `.Site.Languages` in `themes/azzurra/layouts/_default/baseof.html`, deprecated in 0.156.0. It only emits a warning today.

Note this PR and #16 are independent: 0.164.0 does not exhibit the double-escape bug, so the bump alone would mask it, but `htmlUnescape` in #16 is the version-independent fix. Both are worth having.