### PR TITLE
news: announce Grappa, a third-party web IRC client (IT+EN)

### DIFF
--- a/content/en/news/grappa-webclient.md
+++ b/content/en/news/grappa-webclient.md
@@ -1,0 +1,28 @@
+---
+title: "Grappa: another way to reach Azzurra from your browser"
+date: 2026-08-02
+author: "Azzurra Staff"
+tags: ["announcement", "client", "webchat"]
+summary: "Besides the official webchat there's Grappa, a third-party web IRC client: it stays connected for you and follows you across all your devices."
+translationKey: news-grappa-webclient
+---
+
+Here's **one more way** to reach Azzurra from your browser: **Grappa**, a web IRC client built by a member of the community.
+
+👉 https://grappa.chat/
+
+**It is not an official Azzurra client** and it does not replace the [official webchat](/en/news/webchat-back-online/): it's a third-party project under **active development**. We're mentioning it because it's already usable and worth a try — it's a young project, so a few rough edges are to be expected, and reports are welcome.
+
+## How it differs from a webchat
+
+* 🔌 **You stay connected.** Close the window, turn off your phone, come back later: the connection to Azzurra stays up, and you pick the conversation up where you left it.
+* 📱💻 **The same chat on every device.** Open Grappa on your phone, laptop or desktop: it's always your own session, kept in sync.
+* ⚡ **Installs without downloading anything.** On both phone and computer it can be added like a regular app, straight from the browser.
+* 🔑 **Guided nickname registration.** A step-by-step flow walks you through registering; after that you log in from any device with your nickname and password.
+* 🚪 **And if you'd rather not set a password**, you just join with your nickname, the way you always have.
+
+## Try it
+
+Open **https://grappa.chat/** in your browser and connect as you would with any other client. For feedback, questions and reports, join **#grappa**.
+
+*Grappa is an independent project: Azzurra points to it, but does not provide official support for it.*

--- a/content/it/news/grappa-webclient.md
+++ b/content/it/news/grappa-webclient.md
@@ -1,0 +1,28 @@
+---
+title: "Grappa: un altro modo per collegarsi ad Azzurra dal browser"
+date: 2026-08-02
+author: "Staff Azzurra"
+tags: ["annuncio", "client", "webchat"]
+summary: "Oltre alla webchat ufficiale c'è Grappa, un client IRC web di terze parti: resta connesso al posto tuo e ti segue su tutti i dispositivi."
+translationKey: news-grappa-webclient
+---
+
+Segnaliamo agli utenti una **possibilità in più** per collegarsi ad Azzurra dal browser: **Grappa**, un client IRC web sviluppato da un membro della community.
+
+👉 https://grappa.chat/it/
+
+**Non è un client ufficiale Azzurra** e non sostituisce la [webchat ufficiale](/news/webchat-operativa/): è un progetto di terze parti, in **sviluppo attivo**. Lo segnaliamo perché è già utilizzabile e vale la pena provarlo — trattandosi di un progetto giovane, qualche spigolo è normale e le segnalazioni sono benvenute.
+
+## Cosa cambia rispetto a una webchat
+
+* 🔌 **Resti sempre connesso.** Chiudi la finestra, spegni il telefono, torna dopo: la connessione ad Azzurra rimane su, e quando rientri ritrovi la conversazione dov'era.
+* 📱💻 **Stessa chat su tutti i dispositivi.** Apri Grappa dal telefono, dal portatile o dal fisso: è sempre la tua sessione, sincronizzata.
+* ⚡ **Si installa senza scaricare niente.** Su telefono e su PC si aggiunge come un'app normale, direttamente dal browser.
+* 🔑 **Registrazione del nick guidata.** Una procedura passo-passo ti accompagna nella registrazione; da lì in poi entri da qualunque dispositivo con nick e password.
+* 🚪 **E se non vuoi una password**, entri semplicemente col nick, come hai sempre fatto.
+
+## Come provarlo
+
+Apri **https://grappa.chat/it/** nel browser e connettiti come faresti con un normale client. Per feedback, domande e segnalazioni c'è il canale **#grappa**.
+
+*Grappa è un progetto indipendente: Azzurra ne segnala l'esistenza, ma non fornisce supporto ufficiale.*


### PR DESCRIPTION
Adds an IT/EN news entry pointing users to **Grappa** (https://grappa.chat/), a community-built web IRC client that also connects to Azzurra.

Requested by staff on #it-opers: communicate that the option exists, without presenting it as an official Azzurra client.

## Framing

- Explicitly **not** an official client, and **not** a replacement for the official webchat — the post links to the existing webchat news.
- Third-party project under **active development**; the network provides no official support for it.
- Content approved by the project author, who confirmed the public URL, the public name ("Grappa") and the angle to take.

## What the post highlights

User-facing behaviour rather than protocol features: the connection stays up while you're away, the same session follows you across devices, it installs from the browser on phone and desktop, nickname registration is a guided flow, and joining with just a nickname (no password) still works.

## Files

- `content/it/news/grappa-webclient.md`
- `content/en/news/grappa-webclient.md`

Same front-matter shape as the existing news entries, shared `translationKey: news-grappa-webclient`, tags `annuncio/client/webchat` (`announcement/client/webchat` for EN).

## Verification

Built locally with Hugo **0.164.0 extended** (the version pinned by the workflow after #17):

- Build clean; the only warning is the pre-existing `.Site.Languages` deprecation already declared as a follow-up in #17.
- 45 IT + 44 EN pages (was 42 + 41): the two posts plus the new `client` tag pages.
- Both posts render, are listed on their respective home pages, and are cross-linked as translations of each other.
- Internal links resolve: the IT post links `/news/webchat-operativa/` and the EN post links `/en/news/webchat-back-online/` — both verified against the live site (200), and both present in the build output.
- External links verified live: `https://grappa.chat/it/` and `https://grappa.chat/` both return 200. (`https://grappa.chat/en/` is 404, so the EN post links the root.)
- No `&amp;rsquo;` double-escapes in any generated HTML.