### PR TITLE
theme: render the post title once on news pages

### DIFF
--- a/themes/azzurra/layouts/_default/single.html
+++ b/themes/azzurra/layouts/_default/single.html
@@ -27,7 +27,6 @@
         <span class="post-tag">{{ . }}</span>
         {{ end }}{{ end }}
       </div>
-      <h1>{{ .Title }}</h1>
     </header>
     <div class="post-body">
       {{ .Content }}


### PR DESCRIPTION
Requested by Hypnotize: news posts show their title twice.

## What happens

`themes/azzurra/layouts/_default/single.html` renders `.Title` in two places on the
news branch — the shared page hero (line 4) and again in the article header (line 30).
Static pages are unaffected: only the news branch carried the second heading.

Live example: https://www.azzurra.chat/news/grappa-webclient/ — two `<h1>` with the same
text. The same is true of every older post, e.g. `/news/webchat-operativa/`.

## Change

Drop the duplicate `<h1>` from the article header and keep the hero one, so the page has
a single top-level heading like the rest of the site. One line removed, no CSS change —
the hero already carries the title styling.

## Verified

Built with hugo 0.164.0 extended (the version pinned in `.github/workflows/hugo.yml`),
in a throwaway container:

- 45 IT + 44 EN pages, 96 HTML files — identical to master.
- `<h1>` count per page: 1 on `/news/grappa-webclient/` (IT and EN), 1 on
  `/news/webchat-operativa/`, 1 on the static pages (`/regolamento/`, `/servizi/`).
- No `&amp;rsquo;` in any generated HTML (the #16 fix still holds).

## Follow-up, not in this PR

The RSS feeds (`index.xml`, `news/index.xml`, the per-tag ones) still emit `&amp;rsquo;`
in the item descriptions — same double-escape class as #16 but in the built-in RSS
template, which uses `.Summary` directly. Out of scope here; happy to send a separate PR
if you want it fixed.