### PR TITLE
news(grappa): aggiungi temi e notifiche push

### DIFF
--- a/content/en/news/grappa-webclient.md
+++ b/content/en/news/grappa-webclient.md
@@ -18,6 +18,8 @@ Here's **one more way** to reach Azzurra from your browser: **Grappa**, a web IR
 * 🔌 **You stay connected.** Close the window, turn off your phone, come back later: the connection to Azzurra stays up, and you pick the conversation up where you left it.
 * 📱💻 **The same chat on every device.** Open Grappa on your phone, laptop or desktop: it's always your own session, kept in sync.
 * ⚡ **Installs without downloading anything.** On both phone and computer it can be added like a regular app, straight from the browser.
+* 🔔 **Push notifications, if you want them.** Even with the window closed it tells you when someone messages you privately or mentions you in a channel; you decide what earns one — mentions only, a whole channel, or nothing at all.
+* 🎨 **Pick your own colours.** There's a gallery of themes, each with a light and a dark variant, plus an editor to build your own.
 * 🔑 **Guided nickname registration.** A step-by-step flow walks you through registering; after that you log in from any device with your nickname and password.
 * 🚪 **And if you'd rather not set a password**, you just join with your nickname, the way you always have.
 

--- a/content/it/news/grappa-webclient.md
+++ b/content/it/news/grappa-webclient.md
@@ -18,6 +18,8 @@ Segnaliamo agli utenti una **possibilità in più** per collegarsi ad Azzurra da
 * 🔌 **Resti sempre connesso.** Chiudi la finestra, spegni il telefono, torna dopo: la connessione ad Azzurra rimane su, e quando rientri ritrovi la conversazione dov'era.
 * 📱💻 **Stessa chat su tutti i dispositivi.** Apri Grappa dal telefono, dal portatile o dal fisso: è sempre la tua sessione, sincronizzata.
 * ⚡ **Si installa senza scaricare niente.** Su telefono e su PC si aggiunge come un'app normale, direttamente dal browser.
+* 🔔 **Notifiche push, se le vuoi.** Anche a finestra chiusa ti avvisa quando ti scrivono in privato o ti nominano in canale; decidi tu cosa merita una notifica — solo le menzioni, un canale intero, o niente del tutto.
+* 🎨 **I colori te li scegli tu.** C'è una galleria di temi, ognuno con la sua versione chiara e scura, più un editor per farsene uno su misura.
 * 🔑 **Registrazione del nick guidata.** Una procedura passo-passo ti accompagna nella registrazione; da lì in poi entri da qualunque dispositivo con nick e password.
 * 🚪 **E se non vuoi una password**, entri semplicemente col nick, come hai sempre fatto.
 


### PR DESCRIPTION
Su richiesta di vjt (#it-opers), con +1 di Sonic e ok di Hypnotize: la news su Grappa non citava due cose che l'istanza pubblica ha già.

Due bullet in più nella lista "Cosa cambia rispetto a una webchat", IT ed EN in lockstep:

- **Notifiche push** — opt-in, per messaggi privati, menzioni o un canale intero (o niente).
- **Temi** — galleria con variante chiara/scura per ogni tema, più editor per farsene uno.

Entrambe verificate sul commit che gira in produzione, non solo su main. Build locale con hugo extended (45 pagine IT, 44 EN, nessun errore); il build autoritativo resta quello di Pages con 0.164.