### PR TITLE
Add privacy policy page (IT/EN) linked from the footer

### DIFF
--- a/content/en/privacy.md
+++ b/content/en/privacy.md
@@ -1,0 +1,86 @@
+---
+title: "Privacy Policy"
+lead: "How Azzurra IRC Network processes the personal data of those who use the website, the email boxes and the IRC network."
+translationKey: page-privacy
+---
+
+## 1. Data controller
+
+The data controller is **Azzurra IRC Network**.
+
+For any request concerning the processing of your personal data you can write to: **irc@azzurra.chat**
+
+## 2. Data collected through the website
+
+The azzurra.chat website is static and does not implement analytics or tracking tools added directly by us.
+
+The site is distributed through **GitHub** (content hosting) and served through **Cloudflare**, acting as proxy/CDN. In order to operate these services, both providers automatically collect technical data — including the IP address — for security, performance and abuse-prevention purposes, according to their respective policies. We have no direct access to these logs and no control over how they are handled.
+
+## 3. Purposes and legal basis
+
+| Data | Purpose | Legal basis |
+|---|---|---|
+| IP address (technical logs of GitHub and Cloudflare) | Security, performance, abuse prevention | Legitimate interest (art. 6.1.f GDPR), ours and the providers' |
+
+## 4. Data retention
+
+Retention periods for technical logs on the hosting and CDN side are determined by GitHub and Cloudflare according to their respective policies, as they are not directly managed by us:
+
+- GitHub privacy policy: https://docs.github.com/site-policy/privacy-policies/github-privacy-statement
+- Cloudflare privacy policy: https://www.cloudflare.com/privacypolicy/
+
+## 5. Minimum age
+
+Access to Azzurra IRC Network services requires a **minimum age of 14**, in line with art. 2-quinquies of the Italian Privacy Code (Legislative Decree 196/2003, as introduced by Legislative Decree 101/2018). For users under 14, access is allowed only with the consent of whoever holds parental responsibility.
+
+We have no means to technically verify the declared age: compliance with this requirement is therefore left to the user's self-declaration and responsibility.
+
+## 6. Disclosure to third parties
+
+Data collected through the website is not disclosed to third parties beyond what is necessary to provide the service (hosting and CDN, see section 4), except for legal obligations or formal requests from judicial authorities.
+
+GitHub and Cloudflare, being non-EU providers, process data under GDPR-compliant agreements, which provide the safeguards required by law for transfers of data outside the European Union.
+
+## 7. Rights of the data subject
+
+You may exercise at any time the rights provided by artt. 15-22 GDPR (access, rectification, erasure, restriction, portability, objection) by writing to **irc@azzurra.chat**.
+
+You also have the right to lodge a complaint with the Italian Data Protection Authority (www.garanteprivacy.it).
+
+## 8. Security measures
+
+The site is served over an encrypted connection (HTTPS). The handling and security of technical logs follow the measures adopted by GitHub and Cloudflare according to their respective policies (see sections 2 and 4) — we do not directly operate server infrastructure for the website.
+
+## 9. Email boxes
+
+Azzurra IRC Network email boxes (generic and personal) are managed through an external provider, which processes data on our behalf in compliance with the GDPR, including the safeguards required for any non-EU transfers.
+
+We use them to handle support requests and abuse reports: we process the sender's email address and the content of the messages, on the basis of our legitimate interest in ensuring security and assistance to users.
+
+Messages are retained for a maximum of 12 months from the closure of the request, except for repeated abuse requiring longer retention.
+
+## 10. IRC network
+
+In order to provide the service we record some technical connection data: IP address and hostname, used for security and for applying klines and autokills in case of abuse. This data is recorded server-side regardless of public host masking. Connections to the IRC network also support TLS/SSL, an option that is available and recommended to encrypt traffic towards our servers.
+
+The host is masked by default in the public WHOIS for IPv4 connections. For IPv6 connections masking is not currently enabled by default. If you voluntarily disable IPv4 masking, your real host becomes visible on the basis of your explicit choice; you can re-enable masking at any time.
+
+To prevent abuse (bots, open proxies, spambots), connecting IP addresses may be automatically checked against third-party blacklist services (DNSBL).
+
+Some IRC profile fields, such as the realname/gecos, can be set freely by the user and are publicly visible in WHOIS: any personal data voluntarily entered in these fields remains at the user's own discretion and responsibility.
+
+Kline and autokill measures may include a textual reason entered freely by the staff, visible to the user at the moment of the block or disconnection. Autokills also carry an additional internal description, visible to the staff only. These texts may contain personal data relating to the conduct at issue and follow the same retention indicated below for the respective measures.
+
+If you register an account through NickServ, during registration and identification we also process: IP address, email address and date of last access, for account management and security purposes. Nickname registration has a maximum validity of 3650 days (10 years) of inactivity: if the nickname is not used to identify within this period, the registration expires automatically and the data associated with it is removed.
+
+We neither record nor retain logs of channel conversations, nor of private queries between users. Some bots or third-party clients used by users may autonomously log their own conversations: we are not responsible for that, as those are choices outside our control.
+
+General connection data is retained for a maximum of 90 days. Data linked to a temporary disciplinary measure (kline, autokill with expiry) is retained for up to 365 days. In case of a permanent measure (PERM), the data is retained for the whole duration of the measure, subject to periodic review by the staff.
+
+Data associated with a NickServ account (email, settings) is retained as long as the account remains active, with automatic expiry after 3650 days (10 years) of inactivity as indicated above.
+
+---
+
+Policy last updated on 06.08.2026
+
+*This English text is a courtesy translation. In case of discrepancy, the Italian version prevails.*

--- a/content/it/privacy.md
+++ b/content/it/privacy.md
@@ -1,0 +1,84 @@
+---
+title: "Informativa sulla Privacy"
+lead: "Come Azzurra IRC Network tratta i dati personali di chi usa il sito, le caselle email e la rete IRC."
+translationKey: page-privacy
+---
+
+## 1. Titolare del trattamento
+
+Il titolare del trattamento dei dati è **Azzurra IRC Network**.
+
+Per qualsiasi richiesta relativa al trattamento dei tuoi dati personali puoi scrivere a: **irc@azzurra.chat**
+
+## 2. Dati raccolti tramite il sito web
+
+Il sito azzurra.chat è statico e non implementa strumenti di analisi (analytics) o tracciamento aggiunti direttamente da noi.
+
+Il sito è distribuito tramite **GitHub** (hosting dei contenuti) ed è servito attraverso **Cloudflare**, che agisce da proxy/CDN. Per il funzionamento di questi servizi, entrambi i fornitori raccolgono automaticamente dati tecnici — tra cui l'indirizzo IP — per finalità di sicurezza, performance e prevenzione di abusi, secondo le rispettive policy. Non abbiamo accesso diretto a questi log né controllo sulla loro gestione.
+
+## 3. Finalità e base giuridica
+
+| Dato | Finalità | Base giuridica |
+|---|---|---|
+| Indirizzo IP (log tecnici di GitHub e Cloudflare) | Sicurezza, performance, prevenzione abusi | Legittimo interesse (art. 6.1.f GDPR), nostro e dei fornitori |
+
+## 4. Conservazione dei dati
+
+I tempi di conservazione dei log tecnici lato hosting e CDN sono determinati da GitHub e Cloudflare secondo le rispettive policy, non essendo direttamente gestiti da noi:
+
+- Privacy policy GitHub: https://docs.github.com/site-policy/privacy-policies/github-privacy-statement
+- Privacy policy Cloudflare: https://www.cloudflare.com/privacypolicy/
+
+## 5. Età minima
+
+L'accesso ai servizi di Azzurra IRC Network richiede un'**età minima di 14 anni**, in linea con l'art. 2-quinquies del Codice Privacy (D.Lgs. 196/2003, introdotto dal D.Lgs. 101/2018). Per gli utenti che non hanno ancora compiuto 14 anni, l'accesso è consentito solo con il consenso di chi esercita la responsabilità genitoriale.
+
+Non disponiamo di strumenti per verificare tecnicamente l'età dichiarata: il rispetto di questo requisito è pertanto rimesso all'autocertificazione e alla responsabilità dell'utente.
+
+## 6. Comunicazione a terzi
+
+I dati raccolti tramite il sito web non vengono comunicati a terzi al di fuori di quanto necessario per l'erogazione del servizio (hosting e CDN, vedi sezione 4), salvo obblighi di legge o richieste formali da parte dell'autorità giudiziaria.
+
+GitHub e Cloudflare, in quanto fornitori extra-UE, trattano i dati secondo accordi conformi al GDPR, che prevedono le garanzie previste dalla normativa per il trasferimento di dati al di fuori dell'Unione Europea.
+
+## 7. Diritti dell'interessato
+
+Puoi esercitare in qualsiasi momento i diritti previsti dagli artt. 15-22 del GDPR (accesso, rettifica, cancellazione, limitazione, portabilità, opposizione) scrivendo a **irc@azzurra.chat**.
+
+Hai inoltre il diritto di proporre reclamo al Garante per la protezione dei dati personali (www.garanteprivacy.it).
+
+## 8. Misure di sicurezza
+
+Il sito è servito tramite connessione cifrata (HTTPS). La gestione e la sicurezza dei log tecnici seguono le misure adottate da GitHub e Cloudflare secondo le rispettive policy (vedi sezioni 2 e 4) — non gestiamo direttamente infrastrutture server per il sito.
+
+## 9. Caselle email
+
+Le caselle email di Azzurra IRC Network (generiche e nominative) sono gestite tramite un fornitore esterno, che tratta i dati per nostro conto in conformità al GDPR, incluse le garanzie previste per eventuali trasferimenti extra-UE.
+
+Le usiamo per gestire richieste di supporto e segnalazioni di abuso: trattiamo l'indirizzo email del mittente e il contenuto dei messaggi, sulla base del nostro legittimo interesse a garantire sicurezza e assistenza agli utenti.
+
+I messaggi vengono conservati per un massimo di 12 mesi dalla chiusura della richiesta, salvo abusi reiterati che richiedano una conservazione più lunga.
+
+## 10. Rete IRC
+
+Per fornire il servizio registriamo alcuni dati tecnici di connessione: indirizzo IP e hostname, usati per sicurezza e per l'applicazione di kline e autokill in caso di abusi. Questo dato viene registrato lato server indipendentemente dal mascheramento pubblico dell'host. Le connessioni alla rete IRC supportano anche TLS/SSL, opzione disponibile e consigliata per cifrare il traffico verso i nostri server.
+
+L'host è mascherato di default nel WHOIS pubblico per le connessioni IPv4. Per le connessioni IPv6 il mascheramento non è attualmente attivo di default. Se disattivi volontariamente il mascheramento IPv4, il tuo host reale diventa visibile sulla base della tua scelta esplicita; puoi riattivare il mascheramento in qualsiasi momento.
+
+Per prevenire abusi (bot, proxy aperti, spambot), gli indirizzi IP in connessione possono essere verificati automaticamente tramite servizi di blacklist di terze parti (DNSBL).
+
+Alcuni campi del profilo IRC, come il realname/gecos, sono impostabili liberamente dall'utente e visibili pubblicamente in WHOIS: eventuali dati personali inseriti volontariamente in questi campi restano a discrezione e responsabilità dell'utente stesso.
+
+I provvedimenti di kline e autokill possono includere un motivo testuale (reason) inserito liberamente dallo staff, visibile all'utente al momento del blocco o della disconnessione. Gli autokill prevedono inoltre una descrizione interna aggiuntiva, visibile solo allo staff. Questi testi possono contenere dati personali relativi alla condotta contestata e seguono la stessa retention indicata di seguito per i rispettivi provvedimenti.
+
+Se registri un account tramite NickServ, in fase di registrazione e identificazione trattiamo anche: indirizzo IP, indirizzo email e data dell'ultimo accesso, per la gestione dell'account e per finalità di sicurezza. La registrazione del nickname ha una validità massima di 3650 giorni (10 anni) di inattività: se il nickname non viene utilizzato per identificarsi entro questo periodo, la registrazione scade automaticamente e i dati ad essa associati vengono rimossi.
+
+Non registriamo né conserviamo i log delle conversazioni nei canali, né delle query private tra utenti. Alcuni bot o client di terze parti utilizzati dagli utenti potrebbero effettuare autonomamente logging delle proprie conversazioni: non ne siamo responsabili, trattandosi di scelte al di fuori del nostro controllo.
+
+I dati di connessione generali vengono conservati per un massimo di 90 giorni. I dati collegati a un provvedimento disciplinare temporaneo (kline, autokill con scadenza) vengono conservati fino a 365 giorni. In caso di provvedimento permanente (PERM), il dato viene conservato per tutta la durata del provvedimento, soggetto a revisione periodica da parte dello staff.
+
+I dati associati a un account NickServ (email, impostazioni) vengono conservati finché l'account resta attivo, con scadenza automatica dopo 3650 giorni (10 anni) di inattività come indicato sopra.
+
+---
+
+Informativa aggiornata al 06.08.2026

--- a/hugo.toml
+++ b/hugo.toml
@@ -107,6 +107,12 @@ defaultContentLanguageInSubdir = false
     weight = 4
     [languages.it.menus.footer.params]
       col = "info"
+  [[languages.it.menus.footer]]
+    name   = "Privacy"
+    url    = "/privacy"
+    weight = 5
+    [languages.it.menus.footer.params]
+      col = "info"
 
 # ─────────────────────────────────────────────────────────────────────
 # English (served at /en/)
@@ -198,5 +204,11 @@ defaultContentLanguageInSubdir = false
     name   = "Contact"
     url    = "/en/contact"
     weight = 4
+    [languages.en.menus.footer.params]
+      col = "info"
+  [[languages.en.menus.footer]]
+    name   = "Privacy"
+    url    = "/en/privacy"
+    weight = 5
     [languages.en.menus.footer.params]
       col = "info"


### PR DESCRIPTION
Adds the privacy policy to the site in both languages and links it from the footer.

**Changes**
- `content/it/privacy.md` — "Informativa sulla Privacy"
- `content/en/privacy.md` — "Privacy Policy"
- both paired via `translationKey: page-privacy`, so the language switcher hops between them and the i18n parity gate is satisfied
- `hugo.toml` — a "Privacy" entry in the footer "Information"/"Informazioni" column for `it` and `en`

**Content**
Text supplied by the staff, sections 1-10: website (hosting/CDN technical logs), purposes and legal basis, retention, minimum age, disclosure, data-subject rights, security measures, email boxes, IRC network. The English page is a translation and carries a closing note that the Italian version prevails in case of discrepancy.

**Verified locally** with `hugomods/hugo:exts-0.145.0` (the image in `docker-compose.yml`): site builds clean, both pages render (headings, the legal-basis table, the trailing date), the footer link appears on both language trees, and the language switcher on each page points at its counterpart. The parity hook in `.githooks/pre-commit` passes on the staged tree.

**Note for whoever merges:** the page ends with "Informativa aggiornata al 06.08.2026" / "Policy last updated on 06.08.2026" — worth bumping if this lands on a later date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)